### PR TITLE
An attempt to fix the bug with moving figures into the structure.

### DIFF
--- a/Tetris (.NET Core)/GameManager.cs
+++ b/Tetris (.NET Core)/GameManager.cs
@@ -27,12 +27,12 @@ namespace Tetris
                 switch (input)
                 {
                     case TetrisGameInput.Left:
-                       if (this.tetrisGame.CanMoveToLeft())
+                        if (this.tetrisGame.CanMoveToLeft())
                         {
                             this.tetrisGame.CurrentFigureCol--;
                         }
                         break;
-                    case TetrisGameInput.Right:                        
+                    case TetrisGameInput.Right:
                         if (this.tetrisGame.CanMoveToRight())
                         {
                             this.tetrisGame.CurrentFigureCol++;

--- a/Tetris (.NET Core)/GameManager.cs
+++ b/Tetris (.NET Core)/GameManager.cs
@@ -27,13 +27,13 @@ namespace Tetris
                 switch (input)
                 {
                     case TetrisGameInput.Left:
-                        if (this.tetrisGame.CurrentFigureCol >= 1)
+                       if (this.tetrisGame.CanMoveToLeft())
                         {
                             this.tetrisGame.CurrentFigureCol--;
                         }
                         break;
-                    case TetrisGameInput.Right:
-                        if (this.tetrisGame.CurrentFigureCol < tetrisGame.TetrisColumns - this.tetrisGame.CurrentFigure.Height)
+                    case TetrisGameInput.Right:                        
+                        if (this.tetrisGame.CanMoveToRight())
                         {
                             this.tetrisGame.CurrentFigureCol++;
                         }

--- a/Tetris (.NET Core)/ITetrisGame.cs
+++ b/Tetris (.NET Core)/ITetrisGame.cs
@@ -15,5 +15,7 @@
         bool Collision(Tetromino figure);
         void NewRandomFigure();
         void UpdateLevel(int score);
+	bool CanMoveToLeft();
+        bool CanMoveToRight();
     }
 }

--- a/Tetris (.NET Core)/TetrisConsoleWriter.cs
+++ b/Tetris (.NET Core)/TetrisConsoleWriter.cs
@@ -31,7 +31,7 @@ namespace Tetris
             Console.WindowWidth = this.consoleColumns;
             Console.BufferHeight = this.consoleRows + 1;
             Console.BufferWidth = this.consoleColumns;
-            Console.ForegroundColor = ConsoleColor.White;
+            Console.ForegroundColor = ConsoleColor.Black;
             Console.Title = "Tetris v1.0";
             Console.CursorVisible = false;
         }

--- a/Tetris (.NET Core)/TetrisConsoleWriter.cs
+++ b/Tetris (.NET Core)/TetrisConsoleWriter.cs
@@ -31,7 +31,7 @@ namespace Tetris
             Console.WindowWidth = this.consoleColumns;
             Console.BufferHeight = this.consoleRows + 1;
             Console.BufferWidth = this.consoleColumns;
-            Console.ForegroundColor = ConsoleColor.Black;
+            Console.ForegroundColor = ConsoleColor.White;
             Console.Title = "Tetris v1.0";
             Console.CursorVisible = false;
         }

--- a/Tetris (.NET Core)/TetrisGame.cs
+++ b/Tetris (.NET Core)/TetrisGame.cs
@@ -150,7 +150,6 @@ namespace Tetris
                     lines++;
                 }
             }
-
             return lines;
         }
 
@@ -175,13 +174,10 @@ namespace Tetris
                     {
                         return true;
                     }
-
                 }
             }
-
             return false;
         }
-
  	    
         public bool CanMoveToLeft()
         {

--- a/Tetris (.NET Core)/TetrisGame.cs
+++ b/Tetris (.NET Core)/TetrisGame.cs
@@ -181,5 +181,31 @@ namespace Tetris
 
             return false;
         }
+
+ 	public bool CanMoveToLeft()
+        {
+            return (this.CurrentFigureCol >= 1 && !CheckForCollision(-1));            
+        }
+
+        public bool CanMoveToRight()
+        {
+            return (this.CurrentFigureCol < this.TetrisColumns - this.CurrentFigure.Height)
+                && !CheckForCollision(1);
+        }
+        private bool CheckForCollision(int direction) //direction = -1 left, = 1 right
+        {
+            for (int row = 0; row < CurrentFigure.Width; row++)
+            {
+                for (int col = 0; col < CurrentFigure.Height; col++)
+                {
+                    if (CurrentFigure.Body[row, col] &&
+                        this.TetrisField[this.CurrentFigureRow + row, this.CurrentFigureCol + col + direction])
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }               
     }
 }

--- a/Tetris (.NET Core)/TetrisGame.cs
+++ b/Tetris (.NET Core)/TetrisGame.cs
@@ -182,7 +182,8 @@ namespace Tetris
             return false;
         }
 
- 	public bool CanMoveToLeft()
+ 	    
+        public bool CanMoveToLeft()
         {
             return (this.CurrentFigureCol >= 1 && !CheckForCollision(-1));            
         }


### PR DESCRIPTION
BUG Descption: It is possible to make one or more moves (left or right) with current figure inside the non-movable tetris structure. This should not be a valid move for this game. The reason for this is the current left and right move logic that checks only for the field sides collision but not with the tetris structure left from old figures.

BUG Fixing proposed: Adding and additional checks for collision with the structure before permiting to move current figure left or right.